### PR TITLE
Integrate Ory Hydra for OAuth2 & OIDC

### DIFF
--- a/config/hydra/hydra.yml
+++ b/config/hydra/hydra.yml
@@ -1,0 +1,61 @@
+serve:
+  cookies:
+    same_site_mode: Lax # Recommended for most setups
+
+dsn: postgres://hydra:secret@postgresd:5432/hydra?sslmode=disable&max_conns=20&max_idle_conns=4
+
+urls:
+  self:
+    issuer: http://127.0.0.1:4444 # External URL for clients
+  consent: http://127.0.0.1:3000/consent # Points to our consent app
+  login: http://127.0.0.1:3000/login # Points to our consent app's login
+  logout: http://127.0.0.1:3000/logout # Points to our consent app's logout
+  # device flow URLs, can be left as is or updated if device flow is used
+  # verification_ui: http://127.0.0.1:3000/device
+  # post_verification_ui: http://127.0.0.1:3000/device-verified
+
+secrets:
+  system:
+    # IMPORTANT: THESE ARE PLACEHOLDERS AND MUST BE REPLACED WITH STRONG RANDOM VALUES
+    # Generate with: openssl rand -hex 32 (repeat for multiple if needed, but one is usually enough)
+    - "CHANGE_THIS_TO_A_SECURE_RANDOM_STRING_1"
+    - "CHANGE_THIS_TO_A_SECURE_RANDOM_STRING_2"
+  cookie:
+    # IMPORTANT: THIS IS A PLACEHOLDER AND MUST BE REPLACED WITH A STRONG RANDOM VALUE
+    # Generate with: openssl rand -hex 32
+    - "CHANGE_THIS_TO_A_SECURE_RANDOM_COOKIE_SECRET"
+
+
+oidc:
+  subject_identifiers:
+    supported_types:
+      - pairwise
+      - public
+    pairwise:
+      salt: "CHANGE_THIS_TO_A_SECURE_RANDOM_SALT_STRING" # IMPORTANT: Must be changed
+
+# Optional: Enable debug logging if needed, can also be set by env var
+# log:
+#   level: debug
+#   format: text # or json
+
+ttl:
+  access_token: 1h # 1 hour
+  refresh_token: 720h # 30 days
+  id_token: 1h # 1 hour
+  auth_code: 10m # 10 minutes
+  # login_consent_request: 1h # 1 hour
+
+oauth2:
+  expose_internal_errors: true # Useful for debugging, consider false for production
+  pkce:
+    enabled: true # Recommended for public clients
+
+# Setting this to true allows Hydra to work behind a load balancer that terminates TLS
+serve:
+  public:
+    tls:
+      enabled: false # Set to true if you have TLS termination at Hydra itself
+  admin:
+    tls:
+      enabled: false # Set to true if you have TLS termination at Hydra itself

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -7,12 +7,15 @@ services:
       dockerfile: Dockerfile
     ports:
       - "8080:8080" # Expose server port to host
-    environment:
-      - KEEPER_PORT=8080 # Port inside the container
-      - KEEPER_DB_PATH=/data/keeper.db
     volumes:
       - ./data:/data # Bind mount for SQLite database persistence
     restart: unless-stopped
+    environment:
+      - KEEPER_PORT=8080
+      - KEEPER_DB_PATH=/data/keeper.db
+      - HYDRA_ADMIN_URL=http://hydra:4445
+    networks:
+      - intranet
 
   ui:
     build:
@@ -23,3 +26,71 @@ services:
     depends_on:
       - server # Optional: UI might start before server is fully ready, but this expresses a dependency
     restart: unless-stopped
+    networks:
+      - intranet
+
+  postgresd:
+    image: postgres:16
+    environment:
+      - POSTGRES_USER=hydra
+      - POSTGRES_PASSWORD=${POSTGRES_PASSWORD} # Changed from 'secret'
+      - POSTGRES_DB=hydra
+    volumes:
+      - postgres_data:/var/lib/postgresql/data
+    restart: unless-stopped
+    networks:
+      - intranet
+
+  hydra-migrate:
+    image: oryd/hydra:v2.3.0
+    environment:
+      - DSN=postgres://hydra:${POSTGRES_PASSWORD}@postgresd:5432/hydra?sslmode=disable # Changed from 'secret'
+    command: migrate -c /etc/config/hydra/hydra.yml sql -e --yes
+    volumes:
+      - ./config/hydra:/etc/config/hydra
+    restart: on-failure
+    depends_on:
+      - postgresd
+    networks:
+      - intranet
+
+  hydra:
+    image: oryd/hydra:v2.3.0
+    ports:
+      - "4444:4444" # public
+      - "4445:4445" # admin
+    environment:
+      - DSN=postgres://hydra:${POSTGRES_PASSWORD}@postgresd:5432/hydra?sslmode=disable # Changed from 'secret'
+      - URLS_SELF_ISSUER=http://127.0.0.1:4444
+      - URLS_LOGIN=http://127.0.0.1:3000/login
+      - URLS_CONSENT=http://127.0.0.1:3000/consent
+      - SECRETS_SYSTEM=youReallyNeedToChangeThis
+      - LOG_LEVEL=debug
+    command: serve -c /etc/config/hydra/hydra.yml all --dev
+    volumes:
+      - ./config/hydra:/etc/config/hydra
+    restart: unless-stopped
+    depends_on:
+      - hydra-migrate
+    networks:
+      - intranet
+
+  consent:
+    image: oryd/hydra-login-consent-node:v2.3.0
+    ports:
+      - "3000:3000"
+    environment:
+      - HYDRA_ADMIN_URL=http://hydra:4445
+      - NODE_TLS_REJECT_UNAUTHORIZED=0
+      - LOG_LEVEL=debug
+    restart: unless-stopped
+    depends_on:
+      - hydra
+    networks:
+      - intranet
+
+volumes:
+  postgres_data:
+
+networks:
+  intranet:

--- a/initialize_hydra_secrets.py
+++ b/initialize_hydra_secrets.py
@@ -1,0 +1,132 @@
+#!/usr/bin/env python3
+
+import os
+import secrets
+import re
+
+# Define paths
+HYDRA_CONFIG_PATH = "config/hydra/hydra.yml"
+DOTENV_PATH = ".env"
+
+def generate_hex_secret(length_bytes: int) -> str:
+    """Generates a hex-encoded random string of length_bytes."""
+    return secrets.token_hex(length_bytes)
+
+def update_hydra_config(config_path: str, new_secrets: dict) -> None:
+    """Reads, updates, and writes Hydra configuration with new secrets."""
+    try:
+        with open(config_path, 'r') as f:
+            content = f.read()
+    except FileNotFoundError:
+        print(f"Error: Hydra configuration file not found at {config_path}")
+        # Create directory if it doesn't exist
+        os.makedirs(os.path.dirname(config_path), exist_ok=True)
+        # Create a dummy file to allow the script to proceed with placeholder values
+        # This is not ideal but allows the script to run if the file is missing
+        # and a subsequent step might populate it.
+        # In a real scenario, this might be an error condition.
+        with open(config_path, 'w') as f:
+            f.write('''\
+secrets:
+  system:
+    - "CHANGE_THIS_TO_A_SECURE_RANDOM_STRING_1"
+    - "CHANGE_THIS_TO_A_SECURE_RANDOM_STRING_2"
+  cookie:
+    - "CHANGE_THIS_TO_A_SECURE_RANDOM_COOKIE_SECRET"
+oidc:
+  subject_identifiers:
+    pairwise:
+      salt: "CHANGE_THIS_TO_A_SECURE_RANDOM_SALT_STRING"
+''')
+        print(f"Created a placeholder Hydra configuration file at {config_path}")
+        with open(config_path, 'r') as f:
+            content = f.read()
+
+
+    original_content = content
+
+    # Update system secrets
+    content = re.sub(
+        r'(\s*-\s*)"CHANGE_THIS_TO_A_SECURE_RANDOM_STRING_1"',
+        rf'\1"{new_secrets["system_secret_1"]}"',
+        content
+    )
+    content = re.sub(
+        r'(\s*-\s*)"CHANGE_THIS_TO_A_SECURE_RANDOM_STRING_2"',
+        rf'\1"{new_secrets["system_secret_2"]}"',
+        content
+    )
+
+    # Update cookie secret
+    content = re.sub(
+        r'(\s*-\s*)"CHANGE_THIS_TO_A_SECURE_RANDOM_COOKIE_SECRET"',
+        rf'\1"{new_secrets["cookie_secret"]}"',
+        content
+    )
+
+    # Update OIDC salt
+    content = re.sub(
+        r'(salt:\s*)"CHANGE_THIS_TO_A_SECURE_RANDOM_SALT_STRING"',
+        rf'\1"{new_secrets["salt_secret"]}"',
+        content
+    )
+
+    if content == original_content:
+        print(f"Warning: No secrets were updated in {config_path}. Placeholders might be missing or already replaced.")
+    else:
+        with open(config_path, 'w') as f:
+            f.write(content)
+        print(f"Successfully updated secrets in {config_path}")
+        if new_secrets.get("system_secret_1"):
+            print(f"  - System secret 1 updated.")
+        if new_secrets.get("system_secret_2"):
+            print(f"  - System secret 2 updated.")
+        if new_secrets.get("cookie_secret"):
+            print(f"  - Cookie secret updated.")
+        if new_secrets.get("salt_secret"):
+            print(f"  - OIDC salt updated.")
+
+
+def create_or_update_dotenv(dotenv_path: str, postgres_password: str) -> None:
+    """Creates or updates the .env file with the PostgreSQL password."""
+    with open(dotenv_path, 'w') as f:
+        f.write(f"POSTGRES_PASSWORD={postgres_password}\n")
+    print(f"Created/Updated {dotenv_path} with POSTGRES_PASSWORD.")
+    print("Important: Ensure your docker-compose.yml uses this POSTGRES_PASSWORD for the 'postgresd' service.")
+    print("You might need to update it from 'secret' to e.g., '${POSTGRES_PASSWORD}'.")
+
+def main():
+    print("Initializing Hydra secrets...")
+
+    # Generate new secrets
+    new_secrets = {
+        "system_secret_1": generate_hex_secret(32),
+        "system_secret_2": generate_hex_secret(32),
+        "cookie_secret": generate_hex_secret(32),
+        "salt_secret": generate_hex_secret(32),
+    }
+    postgres_password = generate_hex_secret(16)
+
+    # Ensure config directory exists (though it should from previous steps)
+    config_dir = os.path.dirname(HYDRA_CONFIG_PATH)
+    if not os.path.exists(config_dir):
+        os.makedirs(config_dir)
+        print(f"Created directory: {config_dir}")
+
+    # Update hydra.yml
+    update_hydra_config(HYDRA_CONFIG_PATH, new_secrets)
+
+    # Create/Update .env file
+    create_or_update_dotenv(DOTENV_PATH, postgres_password)
+
+    # Make the script executable (best effort, might not work in all environments)
+    try:
+        os.chmod(__file__, 0o755)
+        print(f"Made {__file__} executable.")
+    except Exception as e:
+        print(f"Could not make {__file__} executable: {e}")
+
+    print("Hydra secrets initialization complete.")
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
Adds Ory Hydra and a PostgreSQL database to the Docker Compose setup to enable OAuth2 and OpenID Connect capabilities.

Key changes:
- Updated `docker-compose.yml`:
    - Added `postgresd` service for Hydra's database.
    - Added `hydra-migrate` service for database migrations.
    - Added `hydra` service (Ory Hydra itself).
    - Added `consent` service (example login/consent UI).
    - Configured a common network `intranet`.
    - Existing `server` and `ui` services added to the network.
    - `server` service configured with `HYDRA_ADMIN_URL`.
    - PostgreSQL password externalized to `.env` file.
- Added `config/hydra/hydra.yml`:
    - Initial Hydra configuration file with placeholders for secrets.
    - URLs configured for localhost access.
- Added `initialize_hydra_secrets.py`:
    - Python script to generate strong random secrets for system, cookie, and OIDC salt.
    - Updates `config/hydra/hydra.yml` with these secrets.
    - Creates/updates a `.env` file with a random `POSTGRES_PASSWORD`.
- Existing services (`server`, `ui`) are now part of the `intranet` network, and the `server` is configured with Hydra's admin URL.

To use:
1. Run `python initialize_hydra_secrets.py` to set up secrets.
2. Run `docker-compose up -d --build` to start all services.