### PR TITLE
Fix: Remove undefined schema initialization calls for memory adapter

### DIFF
--- a/server/main.go
+++ b/server/main.go
@@ -421,13 +421,7 @@ func main() {
 		userRepo = authmemory.NewInMemoryUserRepository()
 		// In-memory repo New functions typically don't return an error for simple map init
 		// but we call InitUserSchema for consistency with the interface, though it's a no-op.
-		if err = userRepo.InitUserSchema(); err != nil {
-			log.Fatalf("Failed to initialize in-memory user repository schema (no-op should not fail): %v", err)
-		}
 		messageRepo = messagingmemory.NewInMemoryMessageRepository()
-		if err = messageRepo.InitSchema(); err != nil {
-			log.Fatalf("Failed to initialize in-memory message repository schema (no-op should not fail): %v", err)
-		}
 		log.Println("In-memory repositories initialized successfully.")
 	case "sqlite":
 		log.Println("Initializing with SQLite storage adapters.")


### PR DESCRIPTION
Removes calls to `InitUserSchema` and `InitSchema` on `UserRepository` and `MessageRepository` interfaces respectively when the in-memory storage adapter is selected in `server/main.go`.

These methods are not defined in the repository interfaces, causing a build failure. The in-memory adapters do not require explicit schema initialization after construction, and the SQLite adapters handle their own schema setup within their respective constructor functions.

This change resolves the build error:
./main.go:424:21: userRepo.InitUserSchema undefined (type ports.UserRepository has no field or method InitUserSchema) ./main.go:428:24: messageRepo.InitSchema undefined (type ports.MessageRepository has no field or method InitSchema)