### PR TITLE
feat: Add 'make pristine' for enhanced cleanup and update docs

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: init up down status
+.PHONY: init up down status pristine help all
 
 init: up ## Initialize and run database migrations
 	@echo "Waiting for PostgreSQL to be healthy..."
@@ -23,6 +23,11 @@ down: ## Stop and remove all services, networks, and volumes
 
 status: ## Display the status of the Docker Compose services
 	docker-compose ps
+
+pristine: ## Stop services, remove volumes, and all images used by services
+	@echo "Stopping services, removing volumes, and removing images used by services..."
+	docker-compose down -v --rmi all
+	@echo "System cleaned to pristine state (excluding .env and config files)."
 
 help: ## Display this help screen
 	@grep -E '^[a-zA-Z_-]+:.*?## .*$$' $(MAKEFILE_LIST) | sort | awk 'BEGIN {FS = ":.*?## "}; {printf "\033[36m%-20s\033[0m %s\n", $$1, $$2}'

--- a/OPERATIONS.md
+++ b/OPERATIONS.md
@@ -61,6 +61,9 @@ The `Makefile` provides several commands for managing the environment:
 -   **`make help`**:
     Shows a list of available Make commands and their descriptions.
 
+-   **`make pristine`**:
+    Stops all services, removes all volumes, and removes all Docker images used by the services (as defined in `docker-compose.yml`). This is for a complete cleanup of the Docker environment. It does not affect your source files, `.env`, or configuration files in `config/`.
+
 ## Accessing Services
 
 Here are the default ports for accessing the various services:
@@ -106,6 +109,12 @@ To completely reset the environment (e.g., remove all data, containers):
     ```bash
     make down
     ```
+    For a more thorough cleanup that also removes the Docker images used by the services, you can use:
+    ```bash
+    make pristine
+    ```
+    This command is more comprehensive than `make down -v`.
+
 2.  (Optional) If you want to remove the generated secrets and `.env` file to start from scratch:
     ```bash
     rm .env


### PR DESCRIPTION
This commit introduces a new `pristine` target to the Makefile for a more thorough cleanup of the Docker environment and updates the operations manual accordingly.

Makefile Changes:
- Added a new target `make pristine`.
- This target executes `docker-compose down -v --rmi all` to stop services, remove associated volumes, and remove all Docker images used by the services defined in `docker-compose.yml`.
- The `pristine` target has been added to the `.PHONY` list.
- The `help` target in the Makefile will automatically include the description for `pristine` due to the comment convention used.

Documentation (`OPERATIONS.md`):
- Updated the "Common Commands" section to include a description of the new `make pristine` target and its function.
- Updated the "Resetting the Environment" section to mention `make pristine` as a more comprehensive cleanup option compared to `make down -v`.