### PR TITLE
Refactor: Unify repository initialization to a single `Initialize` me…

### DIFF
--- a/server/adapters/auth/memory/user_repository.go
+++ b/server/adapters/auth/memory/user_repository.go
@@ -76,8 +76,8 @@ func (r *InMemoryUserRepository) GetUserByID(id int64) (*models.User, error) {
 	return &userCopy, nil
 }
 
-// InitUserSchema is a no-op for the in-memory repository but satisfies the interface.
-func (r *InMemoryUserRepository) InitUserSchema() error {
+// Initialize is a no-op for the in-memory repository but satisfies the interface.
+func (r *InMemoryUserRepository) Initialize() error {
 	// No schema initialization needed for in-memory store.
 	return nil
 }

--- a/server/adapters/auth/sqlite/user_repository.go
+++ b/server/adapters/auth/sqlite/user_repository.go
@@ -52,18 +52,18 @@ func NewSQLiteUserRepository(dbPath string) (*SQLiteUserRepository, error) {
 	repo := &SQLiteUserRepository{db: db}
 
 	// Initialize schema
-	log.Printf("User repository: Attempting to initialize user schema for database at: %s", dbPath)
-	if err = repo.InitUserSchema(); err != nil {
+	log.Printf("User repository: Attempting to initialize schema for database at: %s", dbPath) // Updated log
+	if err = repo.Initialize(); err != nil { // Updated call
 		db.Close() // Close DB if schema initialization fails
-		return nil, fmt.Errorf("failed to initialize user schema for DB at %s: %w", dbPath, err)
+		return nil, fmt.Errorf("failed to initialize schema for DB at %s: %w", dbPath, err) // Updated error message
 	}
-	// The InitUserSchema method itself logs success/failure of diagnostics.
+	// The Initialize method itself logs success/failure of diagnostics.
 
 	return repo, nil
 }
 
-// InitUserSchema creates the `users` table if it doesn't already exist.
-func (s *SQLiteUserRepository) InitUserSchema() error {
+// Initialize creates the `users` table if it doesn't already exist.
+func (s *SQLiteUserRepository) Initialize() error {
 	query := `
 	CREATE TABLE IF NOT EXISTS users (
 		id INTEGER PRIMARY KEY AUTOINCREMENT,

--- a/server/adapters/messaging/memory/message_repository.go
+++ b/server/adapters/messaging/memory/message_repository.go
@@ -98,8 +98,8 @@ func (r *InMemoryMessageRepository) GetRecentMessages(limit int) ([]models.Messa
 	return msgsCopy, nil
 }
 
-// InitSchema is a no-op for the in-memory repository but satisfies the interface.
-func (r *InMemoryMessageRepository) InitSchema() error {
+// Initialize is a no-op for the in-memory repository but satisfies the interface.
+func (r *InMemoryMessageRepository) Initialize() error {
 	// No schema initialization needed for in-memory store.
 	return nil
 }

--- a/server/adapters/messaging/sqlite/repository.go
+++ b/server/adapters/messaging/sqlite/repository.go
@@ -53,18 +53,18 @@ func NewSQLiteRepository(dbPath string) (*SQLiteRepository, error) {
 	repo := &SQLiteRepository{db: db}
 
 	// Initialize schema
-	log.Printf("Message repository: Attempting to initialize message schema for database at: %s", dbPath)
-	if err = repo.InitSchema(); err != nil {
+	log.Printf("Message repository: Attempting to initialize schema for database at: %s", dbPath) // Updated log
+	if err = repo.Initialize(); err != nil { // Updated call
 		db.Close() // Close DB if schema initialization fails
-		return nil, fmt.Errorf("failed to initialize message schema for DB at %s: %w", dbPath, err)
+		return nil, fmt.Errorf("failed to initialize schema for DB at %s: %w", dbPath, err) // Updated error message
 	}
-	// The InitSchema method itself logs success/failure of diagnostics.
+	// The Initialize method itself logs success/failure of diagnostics.
 
 	return repo, nil
 }
 
-// InitSchema creates the necessary database schema (tables) if they don't already exist.
-func (s *SQLiteRepository) InitSchema() error {
+// Initialize creates the necessary database schema (tables) if they don't already exist.
+func (s *SQLiteRepository) Initialize() error {
 	query := `
 	CREATE TABLE IF NOT EXISTS messages (
 		id INTEGER PRIMARY KEY AUTOINCREMENT,

--- a/server/core/ports/repository.go
+++ b/server/core/ports/repository.go
@@ -4,6 +4,7 @@ import "keeper/server/models"
 
 // MessageRepository defines the interface for message persistence.
 type MessageRepository interface {
+	Initialize() error // Renamed from InitSchema
 	SaveMessage(msg models.Message) (models.Message, error) // Adjusted to return the saved message
 	GetMessages() ([]models.Message, error)
 	GetRecentMessages(limit int) ([]models.Message, error)

--- a/server/core/ports/user_repository.go
+++ b/server/core/ports/user_repository.go
@@ -4,6 +4,7 @@ import "keeper/server/models"
 
 // UserRepository defines the interface for user data persistence.
 type UserRepository interface {
+	Initialize() error // Renamed from InitUserSchema
 	CreateUser(user models.User) error
 	GetUserByUsername(username string) (*models.User, error)
 	GetUserByID(id int64) (*models.User, error)

--- a/server/main.go
+++ b/server/main.go
@@ -420,8 +420,14 @@ func main() {
 		log.Println("Initializing with in-memory storage adapters.")
 		userRepo = authmemory.NewInMemoryUserRepository()
 		// In-memory repo New functions typically don't return an error for simple map init
-		// but we call InitUserSchema for consistency with the interface, though it's a no-op.
+		// but we call Initialize for consistency with the interface, though it's a no-op.
+		if err = userRepo.Initialize(); err != nil { // Updated call
+			log.Fatalf("Failed to initialize in-memory user repository (no-op should not fail): %v", err) // Updated log
+		}
 		messageRepo = messagingmemory.NewInMemoryMessageRepository()
+		if err = messageRepo.Initialize(); err != nil { // Updated call
+			log.Fatalf("Failed to initialize in-memory message repository (no-op should not fail): %v", err) // Updated log
+		}
 		log.Println("In-memory repositories initialized successfully.")
 	case "sqlite":
 		log.Println("Initializing with SQLite storage adapters.")


### PR DESCRIPTION
…thod

This commit addresses the issue of inconsistent and missing initialization methods on repository interfaces and consolidates them into a single `Initialize() error` method per interface. This improves consistency and scalability, following your feedback.

Changes made:

1.  Interfaces Updated:
    *   `ports.UserRepository`: Renamed `InitUserSchema()` to `Initialize()`.
    *   `ports.MessageRepository`: Renamed `InitSchema()` to `Initialize()`.

2.  Implementations Updated:
    *   In-memory adapters (`authmemory.InMemoryUserRepository`, `messagingmemory.InMemoryMessageRepository`): Renamed their respective init methods (`InitUserSchema`, `InitSchema`) to `Initialize()`. These remain no-op methods.
    *   SQLite adapters (`authsqlite.SQLiteUserRepository`, `messagingsqlite.SQLiteRepository`): Renamed their init methods to `Initialize()` and updated their constructors (`NewSQLiteUserRepository`, `NewSQLiteRepository`) to call the new `Initialize()` method.

3.  Main Application Updated:
    *   `server/main.go`: Changed calls from `userRepo.InitUserSchema()` and `messageRepo.InitSchema()` to `userRepo.Initialize()` and `messageRepo.Initialize()` respectively, for the memory adapter case. Associated log messages were also updated.

This resolves the original build error:
  ./main.go:424:21: userRepo.InitUserSchema undefined (type ports.UserRepository has no field or method InitUserSchema)
  ./main.go:428:24: messageRepo.InitSchema undefined (type ports.MessageRepository has no field or method InitSchema)

And implements a more robust initialization pattern.